### PR TITLE
refactor: handle legacy Deno KV records without is_national_holiday

### DIFF
--- a/src/libraries/holiday.ts
+++ b/src/libraries/holiday.ts
@@ -1,20 +1,25 @@
 import { crawler } from '@/libraries/scraper.ts'
 
-type Holiday = { name: string; date: string; is_national_holiday: boolean }
+type Holiday = { name: string; date: string }
 
 export const getHoliday = async (
   kv: Deno.Kv,
   year: string,
   month?: string
-): Promise<Holiday[]> => {
+): Promise<(Holiday & { is_national_holiday: boolean })[]> => {
   const holidays = await getHolidayYearly(kv, year)
 
-  if (!month) return holidays
+  const result = holidays.map((h) => ({
+    ...h,
+    is_national_holiday: !h.name.toLowerCase().includes('cuti bersama'),
+  }))
+
+  if (!month) return result
 
   const monthPadded = month.padStart(2, '0')
   const prefix = `${year}-${monthPadded}`
 
-  return holidays.filter(item => item.date.startsWith(prefix))
+  return result.filter((item) => item.date.startsWith(prefix))
 }
 
 export const getHolidayDate = async (
@@ -37,7 +42,9 @@ export const getHolidayDate = async (
   return {
     date: formattedDate,
     is_holiday: holidayList.length > 0,
-    is_national_holiday: dayHolidays.some((holiday) => holiday.is_national_holiday),
+    is_national_holiday: dayHolidays.some(
+      (holiday) => !holiday.name.toLowerCase().includes('cuti bersama')
+    ),
     holiday_list: holidayList,
   }
 }
@@ -64,9 +71,9 @@ export const getHolidayYearly = async (
   return data
 }
 
-const getData = async (year: string): Promise<Holiday[]> => {
+const getData = (year: string): Promise<Holiday[]> | never[] => {
   try {
-    return await crawler(year)
+    return crawler(year)
   } catch {
     return []
   }

--- a/src/libraries/scraper.ts
+++ b/src/libraries/scraper.ts
@@ -53,7 +53,6 @@ export const crawler = async (year: string) => {
               return {
                 date: `${year}-${month}-${(Number(value) + index).toString().padStart(2, '0')}`,
                 name,
-                is_national_holiday: !name?.toLowerCase().includes('cuti bersama')
               }
             })
         }
@@ -61,7 +60,6 @@ export const crawler = async (year: string) => {
         return {
           date: `${year}-${month}-${day?.padStart(2, '0')}`,
           name,
-          is_national_holiday: !name?.toLowerCase().includes('cuti bersama'),
         }
       })
       .filter(holiday => !!holiday)


### PR DESCRIPTION
# Summary

Refactor holiday data handling to support legacy Deno KV records that do not yet include the is_national_holiday field. This ensures backward compatibility with existing cached data.